### PR TITLE
refactor: 기본프로필 이미지 무거운 svg를 svg-props에서 대체

### DIFF
--- a/src/app/layouts/RootLayout.tsx
+++ b/src/app/layouts/RootLayout.tsx
@@ -10,6 +10,7 @@ const HIDE_TAB_MENU_PATHS = [
   '/signup',
   '/post',
   '/chat-room',
+  '/signup/profile',
   '/',
 ];
 

--- a/src/features/profile/ui/ProfileImageUploader.tsx
+++ b/src/features/profile/ui/ProfileImageUploader.tsx
@@ -1,7 +1,6 @@
 import { ChangeEvent, useEffect, useRef, useState } from 'react';
 
-import uploadfile from '@/shared/assets/icons/upload-file.svg';
-import uploadimage from '@/shared/assets/icons/upload-image.svg';
+import { UploadFile, UploadImageIcon } from '@/shared/assets/svg-props/svg-props';
 import { cn } from '@/shared/lib/utils';
 import { Button } from '@/shared/ui/button';
 import { Input } from '@/shared/ui/input';
@@ -17,9 +16,7 @@ export function ProfileImageUploader({
   className,
   initialImage,
 }: ProfileImageUploaderProps) {
-  const DEFAULT_IMAGE = uploadimage;
-
-  const [preview, setPreview] = useState<string>(initialImage || DEFAULT_IMAGE);
+  const [preview, setPreview] = useState<string | null>(initialImage || null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const previewUrlRef = useRef<string | null>(null);
 
@@ -70,17 +67,22 @@ export function ProfileImageUploader({
           'cursor-pointer',
         )}
       >
-        {/* 프로필 이미지 미리보기 */}
-        <img
-          src={preview}
-          alt="프로필 이미지"
-          className="h-full w-full rounded-full bg-gray-200 object-cover group-hover:brightness-90 hover:brightness-90"
-        />
+        {/* 프로필 이미지 미리보기 또는 기본 회색 아이콘 */}
+        {preview ? (
+          <img
+            src={preview}
+            alt="프로필 이미지"
+            className="size-full rounded-full bg-gray-200 object-cover group-hover:brightness-90"
+          />
+        ) : (
+          <div className="flex size-full items-center justify-center overflow-hidden rounded-full bg-gray-200 group-hover:brightness-90">
+            <UploadImageIcon className="size-full" />
+          </div>
+        )}
 
         {/* 초록색 사진 아이콘 뱃지 */}
         <div
           className={cn(
-            // 1. 기본 위치 및 형태
             'absolute right-0 bottom-0 z-10 flex h-10 w-10 items-center justify-center',
             'rounded-full border-2 border-white text-white',
             'transition-all duration-300',
@@ -88,7 +90,7 @@ export function ProfileImageUploader({
             'bg-[var(--color-primary-green)] group-hover:brightness-90 hover:brightness-90',
           )}
         >
-          <img src={uploadfile} alt="업로드 아이콘" className="h-10 w-10" />
+          <UploadFile className="size-5" />
         </div>
       </Button>
 

--- a/src/shared/assets/svg-props/svg-props.tsx
+++ b/src/shared/assets/svg-props/svg-props.tsx
@@ -6,16 +6,8 @@ interface IconProps {
 }
 
 /* upload file·image */
-export const UploadFile = ({ size = 50, color = 'currentColor', ...props }: IconProps) => (
-  <svg
-    width={size}
-    height={size}
-    viewBox="0 0 50 50"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-    {...props}
-  >
-    <circle cx="25" cy="25" r="25" fill="#11CC27" />
+export const UploadFile = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="13 13 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
     <path
       d="M33.1667 14.5H16.8333C15.5447 14.5 14.5 15.5447 14.5 16.8333V33.1667C14.5 34.4553 15.5447 35.5 16.8333 35.5H33.1667C34.4553 35.5 35.5 34.4553 35.5 33.1667V16.8333C35.5 15.5447 34.4553 14.5 33.1667 14.5Z"
       stroke="white"
@@ -76,26 +68,13 @@ export const ImgButton = ({ size = 36, color = 'currentColor', ...props }: IconP
 
 export const UploadImageIcon = (props: React.SVGProps<SVGSVGElement>): React.JSX.Element => (
   <svg
-    width="1em"
-    height="1em"
     viewBox="0 0 110 110"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
     xmlnsXlink="http://www.w3.org/1999/xlink"
     {...props}
   >
-    <path d="M0 0H110V110H0V0Z" fill="url(#pattern_upload_image)" />
-    <defs>
-      <pattern
-        id="pattern_upload_image"
-        patternContentUnits="objectBoundingBox"
-        width="1"
-        height="1"
-      >
-        <use xlinkHref="#image_upload_image" transform="matrix(0.00909 0 0 0.00909 0 0)" />
-      </pattern>
-      <image id="image_upload_image" width="110" height="110" xlinkHref="/upload-image.webp" />
-    </defs>
+    <image x="0" y="0" width="110" height="110" href="/upload-image.webp" />
   </svg>
 );
 


### PR DESCRIPTION
[refactor: 기본프로필 이미지 무거운 svg를 svg-props에서 대체]

RootLayout 의 HIDE_TAB_MENU_PATHS  에다가 '/signup/profile', 경로 추가

